### PR TITLE
listener constraint localhost removed. WORKDIR added.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ COPY . /src/.
 
 EXPOSE 8000
 
-CMD python3 -m http.server 8000 -b localhost
+WORKDIR /src/
+CMD python3 -m http.server 8000


### PR DESCRIPTION
Figured out why containerized application did not work on Google Cloud.
1. Dockerfile did not have working directory and used / (root) by default, not /src where the source files are
2. If python http server with "-b localhost" option is defined, the server refuses to respond to any other address than localhost